### PR TITLE
make chimp accept input files with different format

### DIFF
--- a/chimp/data/input.py
+++ b/chimp/data/input.py
@@ -196,7 +196,16 @@ class InputDataset(InputBase):
                     vars = [vars]
                 all_data = []
                 for vrbl in vars:
-                    x_s = data[vrbl][dict(zip(self.spatial_dims, slices))].data
+                    for param, params in vrbl.items():
+                        if param in data:
+                            x_s = data[param][dict(zip(self.spatial_dims, slices))].data
+                        else:
+                            x_s = np.dstack(
+                                [
+                                    data[p][dict(zip(self.spatial_dims, slices))].data
+                                    for p in params
+                                ]
+                            )
                     if np.issubdtype(x_s.dtype, np.timedelta64):
                         x_s = x_s.astype("timedelta64[m]").astype("float32")
                         x_s[x_s < -1e16] = np.nan

--- a/chimp/data/seviri.py
+++ b/chimp/data/seviri.py
@@ -93,7 +93,7 @@ class SEVIRIL1B(InputDataset):
                 from which to extract the observations.
             channel_configuration: A 'str' specifying the channel configuration.
         """
-        super().__init__(name, "seviri", 4, ["obs"])
+        super().__init__(name, name, 4, {"obs": CHANNEL_CONFIGURATIONS[channel_configuration]})
         self.pansat_product = pansat_product
         if not channel_configuration.upper() in CHANNEL_CONFIGURATIONS:
             raise RuntimeError(


### PR DESCRIPTION
This small PR will make chimp to accept satpy remapped SEVIRI files as input.

The chimp remapped SEVIRI file contain the quantity "obs" with dimension ("y", "x", "channels").
The satpy remapped SEVIRI file contains the quantities "HRV", "VIS006", "VIS008", .... with dimension ("y", "x").
With the suggested change chimp should be able to handle both type of files.

  I was not able to add a test for this change since the related test file (test_input.py) seems broken. 

If this is an acceptable change, we should also modify other modules in chimp/data so they are consistent to the change in seviri.py