### PR TITLE
Fix #3 by replacing `self.n_dims` (typo) with `self.n_dim` (correct)

### DIFF
--- a/chimp/data/gridsat.py
+++ b/chimp/data/gridsat.py
@@ -206,7 +206,7 @@ class GridSat(InputDataset):
         rel_scale = self.scale / base_scale
 
         if isinstance(crop_size, int):
-            crop_size = (crop_size,) * self.n_dims
+            crop_size = (crop_size,) * self.n_dim
         crop_size = tuple((int(size / rel_scale) for size in crop_size))
 
         if input_file is not None:

--- a/chimp/data/input.py
+++ b/chimp/data/input.py
@@ -182,7 +182,7 @@ class InputDataset(InputBase):
         rel_scale = self.scale / base_scale
 
         if isinstance(crop_size, int):
-            crop_size = (crop_size,) * self.n_dims
+            crop_size = (crop_size,) * self.n_dim
         crop_size = tuple((int(size / rel_scale) for size in crop_size))
 
         if input_file is not None:

--- a/chimp/data/patmosx.py
+++ b/chimp/data/patmosx.py
@@ -262,7 +262,7 @@ class PATMOSX(InputDataset):
         rel_scale = self.scale / base_scale
 
         if isinstance(crop_size, int):
-            crop_size = (crop_size,) * self.n_dims
+            crop_size = (crop_size,) * self.n_dim
         crop_size = tuple((int(size / rel_scale) for size in crop_size))
 
         if input_file is not None:

--- a/chimp/data/reference.py
+++ b/chimp/data/reference.py
@@ -153,7 +153,7 @@ class ReferenceDataset(DataSource):
         from pytorch_retrieve.tensors.masked_tensor import MaskedTensor
         rel_scale = self.scale / base_scale
         if isinstance(crop_size, int):
-            crop_size = (crop_size,) * self.n_dims
+            crop_size = (crop_size,) * self.n_dim
         crop_size = tuple((int(size / rel_scale) for size in crop_size))
         row_slice, col_slice = scale_slices(slices, rel_scale)
 


### PR DESCRIPTION
This PR fixes #3 by simply replacing all (four) instances of `self.n_dims` to `self.n_dim`

